### PR TITLE
Isaac: add placeholder pages for Recommendation requests

### DIFF
--- a/frontend/src/main/pages/Recommendations/RecommendationsCreatePage.js
+++ b/frontend/src/main/pages/Recommendations/RecommendationsCreatePage.js
@@ -1,0 +1,17 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function RecommendationsCreatePage() {
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+            <h1>Create New Recommendation Request</h1>
+            
+            <p>Placeholder for form to create Recommendation request</p>    
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/Recommendations/RecommendationsEditPage.js
+++ b/frontend/src/main/pages/Recommendations/RecommendationsEditPage.js
@@ -1,0 +1,19 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function RecommendationsEditPage() {
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit Recommendation Request</h1>
+        
+        <p>Placeholder for Recommendation Request edit page</p>
+      </div>
+    </BasicLayout>
+  )
+}
+

--- a/frontend/src/main/pages/Recommendations/RecommendationsIndexPage.js
+++ b/frontend/src/main/pages/Recommendations/RecommendationsIndexPage.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
+
+export default function RecommendationsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: recommendation, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/recommendations/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/recommendations/all" },
+      []
+    );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Recommendation Requests</h1>
+        <p>Placeholder Index Page</p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/Recommendations/RecommendationsCreatePage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsCreatePage.test.js
@@ -1,0 +1,57 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import RecommendationsCreatePage from "main/pages/Recommendations/RecommendationsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+
+describe("RecommendationsCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Recommendations/RecommendationsEditPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsEditPage.test.js
@@ -1,0 +1,55 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RecommendationsEditPage from "main/pages/Recommendations/RecommendationsEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import _mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            code: "ortega"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("RecommendationsEditPage tests", () => {
+
+    describe("tests where backend is working normally", () => {
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationsEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+       
+    });
+});
+
+

--- a/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
@@ -1,0 +1,81 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RecommendationsIndexPage from "main/pages/Recommendations/RecommendationsIndexPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import _mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("RecommendationsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "ReommendationsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+});


### PR DESCRIPTION
Adds 3 placeholder pages for Recommendation requests: Index (list all), Create, and Edit.
Adds related unit tests: verified 100% frontend test coverage
<img width="522" alt="Screen Shot 2022-11-09 at 2 12 47 AM" src="https://user-images.githubusercontent.com/20908336/200803144-20342a26-7914-4b99-ad14-c2bfa15d1fc5.png">
Closes #27 