### PR TITLE
Isaac: add URLs/routing for all placeholder pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,11 +16,33 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import MenuItemIndexPage from "main/pages/MenuItem/MenuItemIndexPage";
+import MenuItemCreatePage from "main/pages/MenuItem/MenuItemCreatePage";
+import MenuItemEditPage from "main/pages/MenuItem/MenuItemEditPage";
+
+import OrganizationIndexPage from "main/pages/Organization/OrganizationIndexPage";
+import OrganizationCreatePage from "main/pages/Organization/OrganizationCreatePage";
+import OrganizationEditPage from "main/pages/Organization/OrganizationEditPage";
+
+import RecommendationsIndexPage from "main/pages/Recommendations/RecommendationsIndexPage";
+import RecommendationsCreatePage from "main/pages/Recommendations/RecommendationsCreatePage";
+import RecommendationsEditPage from "main/pages/Recommendations/RecommendationsEditPage";
+
+import ReviewIndexPage from "main/pages/Review/ReviewIndexPage";
+import ReviewCreatePage from "main/pages/Review/ReviewCreatePage";
+import ReviewEditPage from "main/pages/Review/ReviewEditPage";
+
+import HelpRequestsIndexPage from "main/pages/HelpRequests/HelpRequestsIndexPage";
+import HelpRequestsCreatePage from "main/pages/HelpRequests/HelpRequestsCreatePage";
+import HelpRequestsEditPage from "main/pages/HelpRequests/HelpRequestsEditPage";
+
+import ArticleIndexPage from "main/pages/Article/ArticleIndexPage"
+import ArticleCreatePage from "main/pages/Article/ArticleCreatePage"
+import ArticleEditPage from "main/pages/Article/ArticleEditPage"
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
-
 
 function App() {
 
@@ -70,6 +92,96 @@ function App() {
             <>
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/menuitem/list" element={<MenuItemIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/menuitem/create" element={<MenuItemCreatePage />} />
+              <Route exact path="/menuitem/edit/:id" element={<MenuItemEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/organization/list" element={<OrganizationIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/organization/create" element={<OrganizationCreatePage />} />
+              <Route exact path="/organization/edit/:id" element={<OrganizationEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/recommendation/list" element={<RecommendationsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/recommendation/create" element={<RecommendationsCreatePage />} />
+              <Route exact path="/recommendation/edit/:id" element={<RecommendationsEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/review/list" element={<ReviewIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/review/create" element={<ReviewCreatePage />} />
+              <Route exact path="/review/edit/:id" element={<ReviewEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/helprequest/list" element={<HelpRequestsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/helprequest/create" element={<HelpRequestsCreatePage />} />
+              <Route exact path="/helprequest/edit/:id" element={<HelpRequestsEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/article/list" element={<ArticleIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/article/create" element={<ArticleCreatePage />} />
+              <Route exact path="/article/edit/:id" element={<ArticleEditPage />} />
             </>
           )
         }


### PR DESCRIPTION
Closes #49 

Routes all placeholder pages to the appropriate link extension

/[item]/list for IndexPage
/[item]/create for CreatePage
/[item]/:id for EditPage