### PR TITLE
Isaac: Replace placeholders for Recommendation pages

### DIFF
--- a/frontend/src/main/pages/Recommendation/RecommendationCreatePage.js
+++ b/frontend/src/main/pages/Recommendation/RecommendationCreatePage.js
@@ -10,7 +10,6 @@ export default function RecommendationCreatePage() {
         url: "/api/recommendations/post",
         method: "POST",
         params: {
-            id: recommendation.id,
             requesterEmail: recommendation.requesterEmail,
             professorEmail: recommendation.professorEmail,
             explanation: recommendation.explanation,

--- a/frontend/src/main/pages/Recommendation/RecommendationCreatePage.js
+++ b/frontend/src/main/pages/Recommendation/RecommendationCreatePage.js
@@ -1,16 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import { Navigate } from 'react-router-dom'
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { toast } from "react-toastify";
+import RecommendationForm from "main/components/Recommendation/RecommendationForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
 export default function RecommendationCreatePage() {
+
+    const objectToAxiosParams = (recommendation) => ({
+        url: "/api/recommendations/post",
+        method: "POST",
+        params: {
+            id: recommendation.id,
+            requesterEmail: recommendation.requesterEmail,
+            professorEmail: recommendation.professorEmail,
+            explanation: recommendation.explanation,
+            dateRequested: recommendation.dateRequested,
+            dateNeeded: recommendation.dateNeeded,
+            done: recommendation.done,
+        }
+    });
+
+    const onSuccess = (recommendation) => {
+        toast(`New Recommendation Request Created - id: ${recommendation.id} requester email: ${recommendation.requesterEmail}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/recommendations/all"]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess) {
+        return <Navigate to="/recommendation/list" />
+    }
 
     return (
         <BasicLayout>
             <div className="pt-2">
             <h1>Create New Recommendation Request</h1>
             
-            <p>Placeholder for form to create Recommendation request</p>    
+            <RecommendationForm submitAction={onSubmit} />    
             </div>
         </BasicLayout>
     )

--- a/frontend/src/main/pages/Recommendation/RecommendationEditPage.js
+++ b/frontend/src/main/pages/Recommendation/RecommendationEditPage.js
@@ -1,17 +1,72 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import { useParams } from "react-router-dom";
-// import { Navigate } from 'react-router-dom'
-// import { useBackend, useBackendMutation } from "main/utils/useBackend";
-// import { toast } from "react-toastify";
+import { useParams } from "react-router-dom";
+import RecommendationForm from "main/components/Recommendation/RecommendationForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
 export default function RecommendationEditPage() {
+
+  let { id } = useParams();
+
+  const { data: recommendation, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/recommendation?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/recommendations`,
+        params: {
+          id
+        }
+      }
+  );
+
+  const objectToAxiosPutParams = (recommendation) => ({
+    url: "/api/recommendations",
+    method: "PUT",
+    params: {
+      id: recommendation.id,
+    },
+    data: {
+      requesterEmail: recommendation.requesterEmail,
+      professorEmail: recommendation.professorEmail,
+      explanation: recommendation.explanation,
+      dateRequested: recommendation.dateRequested,
+      dateNeeded: recommendation.dateNeeded,
+      done: recommendation.done,
+    }
+  });
+
+  const onSuccess = (recommendation) => {
+    toast(`Recommendation Request Updated - id: ${recommendation.id} requester email: ${recommendation.requesterEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/recommendations?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/recommendation/list" />
+  }
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Edit Recommendation Request</h1>
         
-        <p>Placeholder for Recommendation Request edit page</p>
+        {recommendation &&
+          <RecommendationForm initialRecommendation={recommendation} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Recommendation/RecommendationIndexPage.js
+++ b/frontend/src/main/pages/Recommendation/RecommendationIndexPage.js
@@ -1,25 +1,28 @@
 import React from 'react'
-// import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
+import RecommendationTable from 'main/components/Recommendation/RecommendationTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function RecommendationIndexPage() {
 
-//   const { data: recommendation, error: _error, status: _status } =
-//     useBackend(
-//       // Stryker disable next-line all : don't test internal caching of React Query
-//       ["/api/recommendations/all"],
-//             // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
-//             { method: "GET", url: "/api/recommendations/all" },
-//       []
-//     );
+  const currentUser = useCurrentUser();
+
+  const { data: recommendation, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/recommendations/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/recommendations/all" },
+      []
+    );
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Recommendation Requests</h1>
-        <p>Placeholder Index Page</p>
+        <RecommendationTable recommendation={recommendation} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/tests/pages/Recommendations/RecommendationCreatePage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render /*, waitFor, fireEvent */ } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import RecommendationCreatePage from "main/pages/Recommendation/RecommendationCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -32,7 +32,7 @@ jest.mock('react-router-dom', () => {
 
 describe("RecommendationCreatePage tests", () => {
 
-    const axiosMock =new AxiosMockAdapter(axios);
+    const axiosMock = new AxiosMockAdapter(axios);
 
     beforeEach(() => {
         axiosMock.reset();
@@ -50,6 +50,68 @@ describe("RecommendationCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+
+        const recommendation = {
+            "id": 17,
+            "requesterEmail": "requester@mail.com",
+            "professorEmail": "professor@mail.com",
+            "explanation": "test post",
+            "dateRequested": "2022-10-10T00:00:00",
+            "dateNeeded": "2022-10-11T00:00:00",
+            "done": true,
+          };
+        
+    
+        axiosMock.onPost("/api/recommendations/post").reply( 202, recommendation );
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(getByTestId("RecommendationForm-requesterEmail")).toBeInTheDocument();
+        });
+
+        const reqField = getByTestId("RecommendationForm-requesterEmail");
+        const profField = getByTestId("RecommendationForm-professorEmail");
+        const explanationField = getByTestId("RecommendationForm-explanation");
+        const dateRequestedField = getByTestId("RecommendationForm-dateRequested");
+        const dateNeededField = getByTestId("RecommendationForm-dateNeeded");
+
+        const submitButton = getByTestId("RecommendationForm-submit");
+
+        fireEvent.change(reqField, { target: { value: 'requester@mail.com' } });
+        fireEvent.change(profField, { target: { value: 'professor@mail.com' } });
+        fireEvent.change(explanationField, { target: { value: 'test post' } });
+        fireEvent.change(dateRequestedField, { target: { value: '2022-10-10T00:00:00' } });
+        fireEvent.change(dateNeededField, { target: { value: '2022-10-11T00:00:00' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            "requesterEmail": "requester@mail.com",
+            "professorEmail": "professor@mail.com",
+            "explanation": "test post",
+            "dateRequested": "2022-10-10T00:00:00",
+            "dateNeeded": "2022-10-11T00:00:00",
+            "done": false,
+        });
+
+        expect(mockToast).toBeCalledWith("New Recommendation Request Created - id: 17 requester email: requester@mail.com");
+        expect(mockNavigate).toBeCalledWith({ "to": "/recommendation/list" });
     });
 
 });

--- a/frontend/src/tests/pages/Recommendations/RecommendationEditPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationEditPage.test.js
@@ -1,4 +1,4 @@
-import { /*fireEvent, */render/*, waitFor*/ } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import RecommendationEditPage from "main/pages/Recommendation/RecommendationEditPage";
@@ -27,7 +27,7 @@ jest.mock('react-router-dom', () => {
         __esModule: true,
         ...originalModule,
         useParams: () => ({
-            code: 1
+            id: 17
         }),
         Navigate: (x) => { mockNavigate(x); return null; }
     };
@@ -44,6 +44,24 @@ describe("RecommendationEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/recommendations", { params: { id: 17 } }).reply(200, {  
+                id: 17,
+                requesterEmail: "req@mail.com",
+                professorEmail: "prof@mail.com",
+                explanation: "original",
+                dateRequested: "2022-10-09T00:00:00",
+                dateNeeded: "2022-10-10T00:00:00",
+                done: false
+            });
+            axiosMock.onPut('/api/recommendations').reply(200, {
+                id: "17",
+                requesterEmail: "newReq@mail.com",
+                professorEmail: "newProf@mail.com",
+                explanation: "new",
+                dateRequested: "2022-10-10T00:00:00",
+                dateNeeded: "2022-10-11T00:00:00",
+                done: true
+            });
         });
 
         const queryClient = new QueryClient();
@@ -55,6 +73,90 @@ describe("RecommendationEditPage tests", () => {
                     </MemoryRouter>
                 </QueryClientProvider>
             );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            const { getByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await waitFor(() => {
+                expect(getByTestId("RecommendationForm-requesterEmail")).toBeInTheDocument();
+            });
+    
+            const reqField = getByTestId("RecommendationForm-requesterEmail");
+            const profField = getByTestId("RecommendationForm-professorEmail");
+            const explanationField = getByTestId("RecommendationForm-explanation");
+            const dateRequestedField = getByTestId("RecommendationForm-dateRequested");
+            const dateNeededField = getByTestId("RecommendationForm-dateNeeded");
+
+            expect(reqField).toHaveValue("req@mail.com");
+            expect(profField).toHaveValue("prof@mail.com");
+            expect(explanationField).toHaveValue("original");
+            expect(dateRequestedField).toHaveValue("2022-10-09T00:00:00");
+            expect(dateNeededField).toHaveValue("2022-10-10T00:00:00")
+        });
+
+        test("Changes when you click Update", async () => {
+
+            const { getByTestId, getByText } = render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <RecommendationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await waitFor(() => {
+                expect(getByTestId("RecommendationForm-requesterEmail")).toBeInTheDocument();
+            });
+    
+            const reqField = getByTestId("RecommendationForm-requesterEmail");
+            const profField = getByTestId("RecommendationForm-professorEmail");
+            const explanationField = getByTestId("RecommendationForm-explanation");
+            const dateRequestedField = getByTestId("RecommendationForm-dateRequested");
+            const dateNeededField = getByTestId("RecommendationForm-dateNeeded");
+            const doneField = getByTestId("RecommendationForm-done");
+
+            expect(reqField).toHaveValue("req@mail.com");
+            expect(profField).toHaveValue("prof@mail.com");
+            expect(explanationField).toHaveValue("original");
+            expect(dateRequestedField).toHaveValue("2022-10-09T00:00:00");
+            expect(dateNeededField).toHaveValue("2022-10-10T00:00:00")
+           
+            const submitButton = getByText("Update");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(reqField, { target: { value: 'newReq@mail.com' } })
+            fireEvent.change(profField, { target: { value: 'newProf@mail.com' } })
+            fireEvent.change(explanationField, { target: { value: "new" } })
+            fireEvent.change(dateRequestedField, { target: { value: "2022-10-10T00:00:00"  } })
+            fireEvent.change(dateNeededField, { target: { value: "2022-10-11T00:00:00"  } })
+            fireEvent.click(doneField)
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled);
+            expect(mockToast).toBeCalledWith("Recommendation Request Updated - id: 17 requester email: newReq@mail.com");
+            expect(mockNavigate).toBeCalledWith({ "to": "/recommendation/list" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                requesterEmail: "newReq@mail.com",
+                professorEmail: "newProf@mail.com",
+                explanation: "new",
+                dateRequested: "2022-10-10T00:00:00",
+                dateNeeded: "2022-10-11T00:00:00",
+                done: true
+            })); // posted object
+
         });
 
        

--- a/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { /* fireEvent, */ render, /* waitFor */ } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import RecommendationIndexPage from "main/pages/Recommendation/RecommendationIndexPage";
@@ -8,6 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import _mockConsole from "jest-mock-console";
+import { recommendationFixtures } from "fixtures/recommendationFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -30,7 +31,7 @@ describe("RecommendationIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
 
-    // const testId = "ReommendationsTable";
+    const testId = "RecommendationTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -75,6 +76,128 @@ describe("RecommendationIndexPage tests", () => {
             </QueryClientProvider>
         );
 
+
+    });
+
+    test("renders three Recommendations without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders three Recommendations without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").timeout();
+
+        const { queryByTestId, getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
+
+        const expectedHeaders = ['Id',  'Requester Email', 'Professor Email','Explanation','Date Requested','Date Needed','Done?'];
+    
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    // test("test what happens when you click delete, admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
+    //     axiosMock.onDelete("/api/recommendations", {params: {code: "1"}}).reply(200, "Recommendation with id 1 was deleted");
+
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <RecommendationIndexPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+    //    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+
+
+    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    //     expect(deleteButton).toBeInTheDocument();
+       
+    //     fireEvent.click(deleteButton);
+
+    //     await waitFor(() => { expect(mockToast).toBeCalledWith("DiningCommons with id de-la-guerra was deleted") });
+
+    // });
+
+    test("test what happens when you click edit as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
+
+
+        const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+        expect(editButton).toBeInTheDocument();
+       
+        fireEvent.click(editButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/recommendation/edit/1'));
 
     });
 


### PR DESCRIPTION
Closes #25 

Adds `RecommendationTable` to `RecommendationIndexPage`, and `RecommendationForm` to `RecommendationCreatePage` and `RecommendationEditPage`. Implements all required API calls. Related tests were also added. Successfully tested on localhost & on heroku.

RecommendationIndexPage mutation coverage:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/20908336/201501846-0a26c51f-7f9f-4e5c-8728-9666a3e4edc8.png">

RecommendationCreatePage mutation coverage:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/20908336/201501858-6e3f1407-c18f-46fb-a3bc-55f5de2526a8.png">

RecommendationEditPage mutation coverage:
<img width="683" alt="image" src="https://user-images.githubusercontent.com/20908336/201501940-fda04436-1566-4645-bb50-f4ade11d29b7.png">