### PR TITLE
Isaac: Change Stryker timeout from 40 to 60 minutes

### DIFF
--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       matrix:


### PR DESCRIPTION
Changes the Stryker timeout in Github Actions to 60 minutes to prevent premature cancellation of mutation testing.