### PR TITLE
Isaac: Add `DELETE` button to Recommendation table

### DIFF
--- a/frontend/src/main/components/Recommendation/RecommendationTable.js
+++ b/frontend/src/main/components/Recommendation/RecommendationTable.js
@@ -1,8 +1,18 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/recommendations",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
 
 export default function RecommendationTable({ recommendation, currentUser }) {
     const navigate = useNavigate();
@@ -11,7 +21,17 @@ export default function RecommendationTable({ recommendation, currentUser }) {
         navigate(`/recommendation/edit/${cell.row.values.id}`)
     }
 
-    // TODO: add delete callback
+    // Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/recommendations/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
 
     const columns = [
         {
@@ -50,6 +70,7 @@ export default function RecommendationTable({ recommendation, currentUser }) {
     const columnsIfAdmin = [
         ...columns,
         ButtonColumn("Edit", "primary", editCallback, testid),
+        ButtonColumn("Delete", "danger", deleteCallback, testid),
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/tests/components/Recommendation/RecommendationTable.test.js
+++ b/frontend/src/tests/components/Recommendation/RecommendationTable.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { recommendationFixtures } from "fixtures/recommendationFixtures";
 import RecommendationTable from "main/components/Recommendation/RecommendationTable"
+import { cellToAxiosParamsDelete } from "main/components/Recommendation/RecommendationTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
@@ -91,9 +92,9 @@ describe("RecommendationTable tests", () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toHaveClass("btn-primary");
 
-    // const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    // expect(deleteButton).toBeInTheDocument();
-    // expect(deleteButton).toHaveClass("btn-danger");
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
 
   });
 
@@ -120,6 +121,25 @@ describe("RecommendationTable tests", () => {
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/recommendation/edit/1'));
 
   });
+
+  describe("cellToAxiosParamsDelete", () => {
+
+    test("It returns the correct params", () => {
+        // arrange
+        const cell = { row: { values: { id: 17 } } };
+
+        // act
+        const result = cellToAxiosParamsDelete(cell);
+
+        // assert
+        expect(result).toEqual({
+            url: "/api/recommendations",
+            method: "DELETE",
+            params: { id: 17 }
+        });
+    });
+
+});
 
 });
 

--- a/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
+++ b/frontend/src/tests/pages/Recommendations/RecommendationsIndexPage.test.js
@@ -143,35 +143,34 @@ describe("RecommendationIndexPage tests", () => {
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
-    // test("test what happens when you click delete, admin", async () => {
-    //     setupAdminUser();
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
 
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
-    //     axiosMock.onDelete("/api/recommendations", {params: {code: "1"}}).reply(200, "Recommendation with id 1 was deleted");
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/recommendations/all").reply(200, recommendationFixtures.threeRecommendations);
+        axiosMock.onDelete("/api/recommendations", {params: {id: 1}}).reply(200, "Recommendation with id 1 was deleted");
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
 
 
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <RecommendationIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
-
-    //    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); 
-
-
-    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    //     expect(deleteButton).toBeInTheDocument();
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
        
-    //     fireEvent.click(deleteButton);
+        fireEvent.click(deleteButton);
 
-    //     await waitFor(() => { expect(mockToast).toBeCalledWith("DiningCommons with id de-la-guerra was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Recommendation with id 1 was deleted") });
 
-    // });
+    });
 
     test("test what happens when you click edit as an admin", async () => {
         setupAdminUser();


### PR DESCRIPTION
Closes #28 

Adds a Delete button to the Recommendation table. On press, this sends a `DELETE` call to `/api/recommendations` with the given ID. Tested and works on localhost.

Coverage:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/20908336/201809156-cb8fba05-133e-447b-9a50-9a9a09bc87e6.png">

Stryker testing:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/20908336/201809243-d6f56703-a74b-4f9d-905b-fcde2ba2c88f.png">
