### PR TITLE
Isaac: Update navbar tests to kill mutants

### DIFF
--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -258,6 +258,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-menuitem-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-menuitem-create/)).toBeInTheDocument() );
 
     });
 
@@ -282,6 +283,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-organization-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-organization-create/)).toBeInTheDocument() );
 
     });
 
@@ -306,6 +308,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-recommendation-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-recommendation-create/)).toBeInTheDocument() );
 
     });
 
@@ -330,6 +333,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-review-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-review-create/)).toBeInTheDocument() );
 
     });
 
@@ -354,6 +358,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-helprequest-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-helprequest-create/)).toBeInTheDocument() );
 
     });
 
@@ -378,6 +383,7 @@ describe("AppNavbar tests", () => {
         expect(aElement).toBeInTheDocument();
         aElement?.click();
         await waitFor( () => expect(getByTestId(/appnavbar-article-list/)).toBeInTheDocument() );
+        await waitFor( () => expect(getByTestId(/appnavbar-article-create/)).toBeInTheDocument() );
 
     });
    


### PR DESCRIPTION
Due to the low timeout time in the Stryker conf, these mutants were not caught (timed out) on initial runs. Now we have 100% mutation strength on Navbar.

<img width="592" alt="image" src="https://user-images.githubusercontent.com/20908336/201840702-622991ae-006d-4d32-81a0-fe1708cd56bf.png">
